### PR TITLE
[bugfix/StripTrailingWhitespace]: Enable Strip trailing whitespace

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -406,7 +406,7 @@ function! <SID>StripTrailingWhitespaces()
     let l = line(".")
     let c = col(".")
     " Do the business:
-    " %s/\s\+$//e
+    %s/\s\+$//e
     " Clean up: restore previous search history, and cursor position
     let @/=_s
     call cursor(l, c)


### PR DESCRIPTION
Removendo configuração de "Strip trailing whitespace" para
compatibilidade com Excel do Gympass.


Close Issue #5