### PR TITLE
[ruby/pronto-default-gems]: Add pronto gems

### DIFF
--- a/ruby/default-gems
+++ b/ruby/default-gems
@@ -1,8 +1,13 @@
 bundler
 flay
 flog
-httparty
-nokogiri
 pry-nav
 rspec
+httparty
+nokogiri
 rubocop
+pronto
+pronto-rubocop
+pronto-flay
+pronto-reek
+pronto-brakeman


### PR DESCRIPTION
Add pronto gems:

- rubocop
- flay
- brakeman
- reek

> INFO: Maybe necessary add 'prontolabs/pronto-rails_best_practices'

> WARN: Beacause :pronto need install CMAKE:
>   Ubuntu Install:
>   `sudo apt-get install cmake`
>
>   Arch Linux:
>   - Pacman: `sudo pacman -S cmake`
>   - Yaourt: `sudo yaourt -S cmake`
>
>   Standalone install: Visit https://cmake.org/install/